### PR TITLE
Update MediaScrubProgressBar Colour

### DIFF
--- a/Sources/Playback/VideoPlayer/MediaScrubProgressBar.swift
+++ b/Sources/Playback/VideoPlayer/MediaScrubProgressBar.swift
@@ -25,7 +25,7 @@ class MediaScrubProgressBar: UIStackView {
         var slider = VLCOBSlider()
         slider.minimumValue = 0
         slider.maximumValue = 1
-        slider.minimumTrackTintColor = .orange
+        slider.minimumTrackTintColor = PresentationTheme.current.colors.orangeUI
         slider.maximumTrackTintColor = UIColor(white: 1, alpha: 0.2)
         slider.setThumbImage(UIImage(named: "sliderThumb"), for: .normal)
         slider.setThumbImage(UIImage(named: "sliderThumbBig"), for: .highlighted)
@@ -42,7 +42,7 @@ class MediaScrubProgressBar: UIStackView {
     private lazy var elapsedTimeLabel: UILabel = {
         var label = UILabel()
         label.font = UIFont.boldSystemFont(ofSize: 13)
-        label.textColor = .orange
+        label.textColor = PresentationTheme.current.colors.orangeUI
         label.text = "--:--"
         label.numberOfLines = 1
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)


### PR DESCRIPTION
Updated the colour of progressSlider and elapsedTimeLabel to match with the default orange colour used across the application and not UIColor.orange .

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the `fastlane` directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
